### PR TITLE
feat: kekw economy - balance system, role restriction, mint command

### DIFF
--- a/cogs/emoji_tracker.py
+++ b/cogs/emoji_tracker.py
@@ -11,6 +11,10 @@ log = logging.getLogger(__name__)
 # Regex to find custom emojis
 CUSTOM_EMOJI_RE = re.compile(r"<a?:.+?:(\d+)>")
 
+# Configuration
+KEKW_EMOJI_NAME_PATTERN = "kekw"  # matches emoji names starting with this (case-insensitive)
+KEKW_RESTRICTED_ROLE_NAME = "is poor"  # role name that blocks kekw usage
+
 class EmojiTracker(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -65,6 +69,55 @@ class EmojiTracker(commands.Cog):
         async with self.pool.acquire() as conn:
             await conn.execute(query)
 
+    async def get_kekw_balance(self, guild_id, user_id):
+        """Get a user's net kekw balance from reaction_received_stats."""
+        if not self.pool:
+            return 0
+        query = """
+        SELECT COALESCE(SUM(count), 0) as total
+        FROM reaction_received_stats
+        WHERE guild_id = $1 AND recipient_id = $2 AND emoji_name ILIKE 'kekw%';
+        """
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(query, guild_id, user_id)
+        return row['total'] if row else 0
+
+    async def decrement_received(self, guild_id, user_id, emoji_name):
+        """Decrement a user's received count (costs them to use kekw)."""
+        if not self.pool:
+            return
+        query = """
+        INSERT INTO reaction_received_stats (guild_id, recipient_id, emoji_name, count)
+        VALUES ($1, $2, $3, -1)
+        ON CONFLICT (guild_id, recipient_id, emoji_name)
+        DO UPDATE SET count = reaction_received_stats.count - 1;
+        """
+        async with self.pool.acquire() as conn:
+            await conn.execute(query, guild_id, user_id, emoji_name)
+
+    async def enforce_kekw_role(self, guild, member):
+        """Add or remove the kekw restricted role based on kekwboard balance."""
+        role = discord.utils.get(guild.roles, name=KEKW_RESTRICTED_ROLE_NAME)
+        if not role:
+            return  # Role doesn't exist yet, skip
+
+        balance = await self.get_kekw_balance(guild.id, member.id)
+        try:
+            if balance <= 0 and role not in member.roles:
+                await member.add_roles(role, reason="kekw balance hit 0")
+                log.info("Added kekw restricted role to %s (balance: %d)", member, balance)
+            elif balance > 0 and role in member.roles:
+                await member.remove_roles(role, reason="kekw balance above 0")
+                log.info("Removed kekw restricted role from %s (balance: %d)", member, balance)
+        except discord.Forbidden:
+            log.warning("Missing permissions to manage roles for %s", member)
+
+    def is_kekw_emoji(self, emoji):
+        """Check if an emoji matches the kekw pattern."""
+        if emoji.name and emoji.name.lower().startswith(KEKW_EMOJI_NAME_PATTERN):
+            return True
+        return False
+
     async def increment_usage(self, guild_id, user_id, emoji_id, is_reaction):
         if not self.pool:
             return
@@ -102,6 +155,37 @@ class EmojiTracker(commands.Cog):
     # --- Event Listeners ---
 
     @commands.Cog.listener()
+    async def on_ready(self):
+        """Configure kekw emoji restrictions on startup."""
+        if not self.pool:
+            return
+        for guild in self.bot.guilds:
+            # Create the restricted role if it doesn't exist
+            restricted_role = discord.utils.get(guild.roles, name=KEKW_RESTRICTED_ROLE_NAME)
+            if not restricted_role:
+                try:
+                    restricted_role = await guild.create_role(
+                        name=KEKW_RESTRICTED_ROLE_NAME,
+                        reason="Auto-created for kekw economy"
+                    )
+                    log.info("Created '%s' role in %s", KEKW_RESTRICTED_ROLE_NAME, guild.name)
+                except discord.Forbidden:
+                    log.warning("Missing permissions to create role in %s", guild.name)
+                    continue
+
+            # Restrict kekw emojis so the role cannot use them
+            if restricted_role:
+                # Build the set of roles that CAN use kekw emojis (all roles except restricted)
+                allowed_roles = [r for r in guild.roles if r != restricted_role]
+                for emoji in guild.emojis:
+                    if emoji.name and emoji.name.lower().startswith(KEKW_EMOJI_NAME_PATTERN):
+                        try:
+                            await emoji.edit(roles=allowed_roles, reason="Restrict kekw emoji from kekw restricted role")
+                            log.info("Restricted emoji %s from '%s' role", emoji.name, KEKW_RESTRICTED_ROLE_NAME)
+                        except discord.Forbidden:
+                            log.warning("Missing Manage Emojis permission to restrict %s", emoji.name)
+
+    @commands.Cog.listener()
     async def on_message(self, message):
         if message.author.bot or not message.guild:
             return
@@ -135,13 +219,75 @@ class EmojiTracker(commands.Cog):
                 try:
                     message = await channel.fetch_message(payload.message_id)
                     if not message.author.bot:
+                        # Skip self-reactions for kekw economy
+                        if self.is_kekw_emoji(emoji) and message.author.id == user_id:
+                            return
+
                         await self.increment_received(guild_id, message.author.id, emoji.name)
+
+                        # --- Kekw balance logic ---
+                        if self.is_kekw_emoji(emoji):
+                            guild = self.bot.get_guild(guild_id)
+                            if guild:
+                                # Decrement the reactor's balance (costs them to use kekw)
+                                reactor = guild.get_member(user_id)
+                                if reactor and not reactor.bot:
+                                    await self.decrement_received(guild_id, user_id, emoji.name)
+                                    await self.enforce_kekw_role(guild, reactor)
+
+                                # Recipient just got +1 from increment_received above, update their role
+                                recipient = guild.get_member(message.author.id)
+                                if recipient and not recipient.bot:
+                                    await self.enforce_kekw_role(guild, recipient)
+
                 except (discord.NotFound, discord.Forbidden):
                     pass
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload):
-        pass
+        if payload.user_id == self.bot.user.id or payload.guild_id is None:
+            return
+
+        guild_id = payload.guild_id
+        user_id = payload.user_id
+        emoji = payload.emoji
+
+        if not emoji.name:
+            return
+
+        # Only process kekw removals
+        if not self.is_kekw_emoji(emoji):
+            return
+
+        channel = self.bot.get_channel(payload.channel_id)
+        if not channel:
+            return
+
+        try:
+            message = await channel.fetch_message(payload.message_id)
+            if message.author.bot:
+                return
+
+            # Skip self-reaction removals
+            if message.author.id == user_id:
+                return
+
+            # Refund the reactor (+1 back to their balance)
+            guild = self.bot.get_guild(guild_id)
+            if guild:
+                reactor = guild.get_member(user_id)
+                if reactor and not reactor.bot:
+                    await self.increment_received(guild_id, user_id, emoji.name)
+                    await self.enforce_kekw_role(guild, reactor)
+
+                # Deduct from the recipient (-1 since they lost the kekw)
+                recipient = guild.get_member(message.author.id)
+                if recipient and not recipient.bot:
+                    await self.decrement_received(guild_id, message.author.id, emoji.name)
+                    await self.enforce_kekw_role(guild, recipient)
+
+        except (discord.NotFound, discord.Forbidden):
+            pass
 
     # --- Commands ---
 
@@ -228,6 +374,54 @@ class EmojiTracker(commands.Cog):
             color=discord.Color.red()
         )
         await ctx.send(embed=embed)
+
+    @commands.command(name="kekwscore")
+    async def kekwscore(self, ctx, target: Optional[discord.Member] = None):
+        """Check your kekw balance (or someone else's). 0 = restricted from using kekw."""
+        if not self.pool:
+            return await ctx.send("Database not connected.")
+
+        member = target or ctx.author
+        balance = await self.get_kekw_balance(ctx.guild.id, member.id)
+
+        role = discord.utils.get(ctx.guild.roles, name=KEKW_RESTRICTED_ROLE_NAME)
+        restricted = role in member.roles if role else False
+
+        status = "🚫 RESTRICTED" if restricted else "✅ Can use kekw"
+        embed = discord.Embed(
+            title=f"KEKW Balance — {member.display_name}",
+            description=f"**Balance:** {balance}\n**Status:** {status}",
+            color=discord.Color.red() if restricted else discord.Color.green()
+        )
+        await ctx.send(embed=embed)
+
+    @commands.command(name="kekwmint", hidden=True)
+    async def kekwmint(self, ctx, target: discord.Member, amount: int = 1):
+        """Mint kekws into a user's balance. Tangster/Centerist role only."""
+        MINT_ROLE_IDS = {1071629030408847371, 1071861949752676372}
+        if not any(r.id in MINT_ROLE_IDS for r in ctx.author.roles):
+            return  # Silently ignore
+
+        if not self.pool:
+            return
+
+        query = """
+        INSERT INTO reaction_received_stats (guild_id, recipient_id, emoji_name, count)
+        VALUES ($1, $2, 'kekw_mint', $3)
+        ON CONFLICT (guild_id, recipient_id, emoji_name)
+        DO UPDATE SET count = reaction_received_stats.count + $3;
+        """
+        async with self.pool.acquire() as conn:
+            await conn.execute(query, ctx.guild.id, target.id, amount)
+
+        # Enforce role in case they were restricted
+        await self.enforce_kekw_role(ctx.guild, target)
+
+        # Delete the command message to hide it
+        try:
+            await ctx.message.delete()
+        except discord.Forbidden:
+            pass
 
 async def setup(bot):
     await bot.add_cog(EmojiTracker(bot))

--- a/cogs/emoji_tracker.py
+++ b/cogs/emoji_tracker.py
@@ -423,5 +423,38 @@ class EmojiTracker(commands.Cog):
         except discord.Forbidden:
             pass
 
+    @commands.command(name="poors")
+    async def poors(self, ctx):
+        """Show everyone with 0 or fewer kekws, poorest first."""
+        if not self.pool:
+            return await ctx.send("Database not connected.")
+
+        query = """
+        SELECT recipient_id, SUM(count) as balance
+        FROM reaction_received_stats
+        WHERE guild_id = $1 AND emoji_name ILIKE 'kekw%'
+        GROUP BY recipient_id
+        HAVING SUM(count) <= 0
+        ORDER BY balance ASC;
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(query, ctx.guild.id)
+
+        if not rows:
+            return await ctx.send("No poors found. Everyone is rich in kekws.")
+
+        lines = []
+        for i, row in enumerate(rows, 1):
+            member = ctx.guild.get_member(row['recipient_id'])
+            name = member.display_name if member else f"Unknown ({row['recipient_id']})"
+            lines.append(f"{i}. **{name}** — {row['balance']} kekws")
+
+        embed = discord.Embed(
+            title="💸 The Poors",
+            description="\n".join(lines),
+            color=discord.Color.dark_grey()
+        )
+        await ctx.send(embed=embed)
+
 async def setup(bot):
     await bot.add_cog(EmojiTracker(bot))


### PR DESCRIPTION
Adds a kekw economy system:
- Reacting with a kekw emoji costs the reactor 1 balance and gives the recipient +1
- Removing a kekw reaction refunds the reactor and deducts from recipient
- Users at 0 balance get the 'is poor' role (auto-created on startup)
- Kekw emojis are restricted from the 'is poor' role via emoji permissions
- Hidden !kekwmint command for Tangster/Centerist roles to inject kekws
- Self-reactions are ignored (no-op)
- !kekwscore command to check balance

Required bot permissions: Manage Roles, Manage Expressions, Read Message History, Manage Messages